### PR TITLE
Fix swagger dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "symfony/dependency-injection": "^4.1",
         "symfony/config": "^4.1",
         "symfony/http-kernel": "^4.1",
-        "zircote/swagger-php": "^3.0"
+        "zircote/swagger-php": "^2.0"
     },
     "authors": [
         {


### PR DESCRIPTION
>[Semantical Error] The annotation "@Swagger\Annotations\Response" in method Tseguier\HealthCheckBundle\Controller\HealthCheckController::getHealth() does not exist, or could not be auto-loaded in vendor/tseguier/health-check/src/Controller/HealthCheckController.php (which is being imported from "/config/routes.yaml"). Make sure annotations are installed and enabled.

>[Semantical Error] The annotation "@Swagger\Annotations\Response" in method Tseguier\HealthCheckBundle\Controller\HealthCheckController::getHealth() does not exist, or could not be auto-loaded.

Changing the version of `zircote/swagger-php` fixes it